### PR TITLE
Fix disk null readwrite

### DIFF
--- a/src/disk.h
+++ b/src/disk.h
@@ -44,6 +44,10 @@ class Block {
     // If `content` is smaller than `block_size`, the trailing bytes are empty.
     Block(const int block_size, const char *content);
 
+    // Initialize the block with `block_size` and `content`.
+    // If `content` is smaller than `block_size`, the trailing bytes are empty.
+    Block(const int block_size, const std::vector<uint8_t> &content);
+
     // Blocksize of this block
     inline size_t BlockSize() const { return content_.size(); }
 


### PR DESCRIPTION
#18 
Null characters or string with trailing space cannot be written to read by `DiskManager::{Read, Write}`. It is because the block content is transformed to `char*` inside these functions. We make it possible to write null characters or trailing spaces by stop using the `char*`.