### PR TITLE
Writing to disk not longer updates the file content

### DIFF
--- a/src/disk.cc
+++ b/src/disk.cc
@@ -148,7 +148,8 @@ DiskManager::DiskManager(const std::string &directory_path,
     : directory_path_(directory_path), block_size_(block_size) {}
 
 Result DiskManager::Read(const BlockID &block_id, Block &block) const {
-    std::ifstream file(directory_path_ + block_id.Filename(), std::ios::binary);
+    std::ifstream file(directory_path_ + block_id.Filename(),
+                       std::ios::ate | std::ios::binary);
     if (!file.is_open())
         return Error("disk::DiskManager::Read() failed to open a file.");
 
@@ -171,7 +172,8 @@ Result DiskManager::Read(const BlockID &block_id, Block &block) const {
 }
 
 Result DiskManager::Write(const BlockID &block_id, const Block &block) const {
-    std::ofstream file(directory_path_ + block_id.Filename(), std::ios::binary);
+    std::ofstream file(directory_path_ + block_id.Filename(),
+                       std::ios::ate | std::ios::binary | std::ios::in);
     if (!file.is_open())
         return Error("disk::DiskManager::Write() failed to open a file.");
 

--- a/src/disk_test.cc
+++ b/src/disk_test.cc
@@ -347,29 +347,29 @@ TEST_F(TempFileTest, DiskManagerCorrectlyWrites) {
     const disk::DiskManager disk_manager(directory_path, /*block_size=*/3);
 
     char goodbye[] = "goodbye";
-    disk::Block block_write(3, goodbye), block_read;
+    disk::Block block_write(3, goodbye), block_read0, block_read1;
 
     EXPECT_TRUE(
         disk_manager.Write(disk::BlockID(filename, 0), block_write).IsOk());
     EXPECT_TRUE(
-        disk_manager.Read(disk::BlockID(filename, 0), block_read).IsOk());
+        disk_manager.Write(disk::BlockID(filename, 1), block_write).IsOk());
+
+    EXPECT_TRUE(
+        disk_manager.Read(disk::BlockID(filename, 0), block_read0).IsOk());
+    EXPECT_TRUE(
+        disk_manager.Read(disk::BlockID(filename, 1), block_read1).IsOk());
 
     // block_read must be "goo"
-    EXPECT_EQ(block_read.ReadByte(0).Get(), 'g');
-    EXPECT_EQ(block_read.ReadByte(1).Get(), 'o');
-    EXPECT_EQ(block_read.ReadByte(2).Get(), 'o');
-    EXPECT_TRUE(block_read.ReadByte(3).IsError());
-
-    EXPECT_TRUE(
-        disk_manager.Write(disk::BlockID(filename, 1), block_write).IsOk());
-    EXPECT_TRUE(
-        disk_manager.Read(disk::BlockID(filename, 1), block_read).IsOk());
+    EXPECT_EQ(block_read0.ReadByte(0).Get(), 'g');
+    EXPECT_EQ(block_read0.ReadByte(1).Get(), 'o');
+    EXPECT_EQ(block_read0.ReadByte(2).Get(), 'o');
+    EXPECT_TRUE(block_read0.ReadByte(3).IsError());
 
     // block must be "goo"
-    EXPECT_EQ(block_read.ReadByte(0).Get(), 'g');
-    EXPECT_EQ(block_read.ReadByte(1).Get(), 'o');
-    EXPECT_EQ(block_read.ReadByte(2).Get(), 'o');
-    EXPECT_TRUE(block_read.ReadByte(3).IsError());
+    EXPECT_EQ(block_read1.ReadByte(0).Get(), 'g');
+    EXPECT_EQ(block_read1.ReadByte(1).Get(), 'o');
+    EXPECT_EQ(block_read1.ReadByte(2).Get(), 'o');
+    EXPECT_TRUE(block_read1.ReadByte(3).IsError());
 }
 
 TEST_F(NonExistentFileTest, DiskManagerWriteFail) {


### PR DESCRIPTION
We have to specify openmode to `std::ios::ate | std::ios::in` when writing to disk so as not to delete the file content.